### PR TITLE
期間予定かつ年をまたぐときのバグ修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ install:
     -   pip3 install -r ./nit-tsuyama/requirements.txt
 script:
     -   cd ./nit-tsuyama-old/
-    -   python3 calconv.py 2016
+    -   python3 calconv.py 2018
     -   cd ../nit-tsuyama/
-    -   python3 calconv.py 2016
+    -   python3 calconv.py 2018

--- a/nit-tsuyama/calconv.py
+++ b/nit-tsuyama/calconv.py
@@ -358,6 +358,7 @@ def main():
                         csv_write.start = digit_conv(month) + '/'
 
                     # 期間予定かの検出
+                    date_end = [] # date_end初期化
                     span = span_search(line)
                     csv_write.start = csv_write.start + date_start_search(line) + '/'
                     # 一日予定
@@ -411,7 +412,7 @@ def main():
                         csv_write.start = csv_write.start + str(year)
                     decem = 12
                     # endは12月予定かつ月を跨いでいるまたは,1~3月なら次の年を設定
-                    if month == decem and span == -2 and date_end[0] or month == decem and date_end[0] or month < 4:
+                    if month == decem and span == -2 or month == decem and date_end[0] or month < 4:
                         csv_write.end = csv_write.end + str(year + 1)
                     else:
                         csv_write.end = csv_write.end + str(year)


### PR DESCRIPTION
### やったこと
* 年をまたぐ予定の際にきちんと次の年賀出力されないバグの修正 #4
* CIの実行コマンド変更
  - 年度の記述を`2018`に変更

### やらないこと
* Doc形式でのコメント書き換え