### PR TITLE
スケジュール部分の終了検知方法修正

### DIFF
--- a/nit-tsuyama/calconv.py
+++ b/nit-tsuyama/calconv.py
@@ -314,7 +314,7 @@ def main():
         i = i + 1
 
     # 予定表部分終了部分(テキストそのままのため、何か終了検出方法を考えるべき)
-    month_end = '<div class="space">'
+    SCHEDULE_END = '</div>'
     # 4月の予定が読み込み開始されたかのフラグ
     month_start_flag = False
     # 予定がコメントアウト中の行にあるかのフラグ
@@ -341,7 +341,7 @@ def main():
 
             if month_start_flag:
                 # 予定表部分が終了した場合,breakする
-                if month_end in line:
+                if SCHEDULE_END in line:
                     break
                 # コメントアウト行終了時にフラグを下ろす
                 elif month_searching == -1:


### PR DESCRIPTION
### やったこと
* スケジュールの検出方法を修正
  - スケジュール部が`<div>`で囲まれるようになったので対応

### やらないこと
* 要素や属性等によるスクレイピング
  - 定義が曖昧で毎年変化するため